### PR TITLE
Add compatibility with Octoprint with Python3

### DIFF
--- a/octoprint_resource_monitor/__init__.py
+++ b/octoprint_resource_monitor/__init__.py
@@ -126,7 +126,7 @@ class ResourceMonitorPlugin(octoprint.plugin.SettingsPlugin,
 
 
 __plugin_name__ = "Resource Monitor"
-
+__plugin_pythoncompat__ = ">=2.7,<4"
 
 def __plugin_load__():
 	global __plugin_implementation__


### PR DESCRIPTION
Tested on my raspi4 with Octoprint 1.4.0rc5 and seems to work so far.