### PR TITLE
Skip resource checking if no UI clients

### DIFF
--- a/octoprint_resource_monitor/__init__.py
+++ b/octoprint_resource_monitor/__init__.py
@@ -36,6 +36,9 @@ class ResourceMonitorPlugin(octoprint.plugin.SettingsPlugin,
 		return 1
 
 	def check_resources(self):
+		if not self._plugin_manager.registered_clients:  # No connected clients to UI
+			return False
+
 		message = dict(
 			cpu=self.get_cpu(),
 			temp=self.get_cpu_temp(),


### PR DESCRIPTION
On my Rock64 board it takes between 15-30ms to query the resource values. It's not necessary to run the check if there is no clients waiting for it.