### PR TITLE
add soc_thermal cpu_temp type for RK3328 SoCs

### DIFF
--- a/octoprint_resource_monitor/monitor.py
+++ b/octoprint_resource_monitor/monitor.py
@@ -21,6 +21,8 @@ class Monitor:
 			cpu_temp = temp["cpu-thermal"][0]._asdict()
 		if "cpu_thermal" in temp:
 			cpu_temp = temp["cpu_thermal"][0]._asdict()
+		if "soc_thermal" in temp:
+			cpu_temp = temp["soc_thermal"][0]._asdict()
 		return cpu_temp
 
 	def __init_process(self):


### PR DESCRIPTION
Thank you for contributing to OctoPrint-Resource-Monitor, it's very appreciated !

Before submitting this PR, make sure you followed the following guidelines.

* [✔️] Your PR targets the `dev` branch
* [✔️]  Your PR was opened from a new branch on your repository
* [✔️]  Your PR does not contain unneeded files or code
* [✔️]  Your changes matches the existing coding style
* [✔️]  You have tested your changes.

---

**What does this PR do ? What does it change or add ?**
Adds `soc_thermal` to the list of possible CPU temperature source names, which is used by RK3328 SoCs and probably many others.

**How did you test it ?**
Run this plug-in on my Octoprint instance, running on a NanoPi NEO3 with RK3328 SoC.

**Screenshots (if applicable)**
None.

**Is this linked to any existing opened issue ? Which one(s) ?**
No.

**Other useful info**
Nothing! Very small PR. :)
