### PR TITLE
Replace deprecated Settings.getBoolean with get_boolean

### DIFF
--- a/octoprint_resource_monitor/__init__.py
+++ b/octoprint_resource_monitor/__init__.py
@@ -57,7 +57,7 @@ class ResourceMonitorPlugin(octoprint.plugin.SettingsPlugin,
 	def check_resources(self):
 		if not self._plugin_manager.registered_clients:  # No connected clients to UI
 			return False
-		if self._settings.getBoolean(["enable_profiling"]):
+		if self._settings.get_boolean(["enable_profiling"]):
 			pr = profile.Profile()
 			pr.enable()
 			message = self.__monitor.get_all_resources()
@@ -75,7 +75,7 @@ class ResourceMonitorPlugin(octoprint.plugin.SettingsPlugin,
 		self.__monitor = Monitor(
 			self._settings.get(["network", "exceptions"]),
 			self._settings.get(["disk", "exceptions"]),
-			self._settings.getBoolean(["use_net_if_stats"]),
+			self._settings.get_boolean(["use_net_if_stats"]),
 			self._logger
 		)
 		RepeatedTimer(self.interval, self.check_resources).start()


### PR DESCRIPTION
This replaces deprecated Settings.getBoolean calls with get_boolean in octoprint_resource_monitor/__init__.py to stop a DeprecationWarning seen in octoprint.log.

Background: OctoPrint renamed getBoolean to get_boolean as part of a settings/webcam refactor (see OctoPrint PR #4628: https://github.com/OctoPrint/OctoPrint/pull/4628) and shipped the change with OctoPrint 1.9.0 (May 23, 2023). This is a rename-only change and does not alter behavior.

Changes:
- Replaced getBoolean with get_boolean for enable_profiling and use_net_if_stats.

Testing: Restart OctoPrint and confirm the DeprecationWarning no longer appears.