### PR TITLE
Add k10temp to temp keys for AMD processors

### DIFF
--- a/octoprint_resource_monitor/monitor/__init__.py
+++ b/octoprint_resource_monitor/monitor/__init__.py
@@ -23,6 +23,7 @@ class Monitor:
 			"cpu_thermal_zone": 1,
 			"acpitz": 1,
 			"scpi_sensors": 1,
+			"k10temp": 1,
 			"aml_thermal": 1000
 		}
 		for key, multiplier in temperature_possible_keys.items():


### PR DESCRIPTION

* [✓] Your PR targets the `dev` branch
* [✓] Your PR was opened from a new branch on your repository
* [✓] Your PR does not contain unneeded files or code
* [✓] Your changes matches the existing coding style
* [✓] You have tested your changes.

---

This pr adds the key `k10temp` to the `temperature_possible_keys` dictionary for AMD processors. My hp thin client with an AMD GX-212JC uses this key.